### PR TITLE
early return on clearing cache

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -112,6 +112,7 @@ Cacher.prototype.clearCache = function clearCache(queryMethod, opts) {
       return this.clearAllCache();
   return new Promise(function promiser(resolve, reject) {
     var key = self.key(queryMethod, opts);
+    if (!key) return resolve();
     return redis.del(key, function onDel(err) {
       if (err) {
         return reject(err);
@@ -125,10 +126,11 @@ Cacher.prototype.clearAllCache = function(){
     var self = this;
     return new Promise(function(resolve, reject){
         return redis.keys(self.cachePrefix + ':' + self.modelName + '*', function(err, keys){
-            return redis.del(keys, function(err){
-                if(err) return reject(err);
-                return resolve();
-            })
+          if (keys.length < 1) return resolve();
+          return redis.del(keys, function(err){
+              if(err) return reject(err);
+              return resolve();
+          })
         })
     })
 }


### PR DESCRIPTION
This commit will avoid the error: 
ERR wrong number of arguments for 'del' command
since it returns early if the redis key is not found.
